### PR TITLE
add: token.go

### DIFF
--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -1,0 +1,72 @@
+package lexer
+
+import (
+	"monkey/token"
+	"testing"
+)
+
+func TestNextToken(t *testing.T) {
+	input := `let five = 5;
+let ten = 10;
+
+let add = fn(x, y) {
+  x + y;
+};
+let result = add(five, ten);
+`
+
+	tests := []struct {
+		expectedType    token.TokenType
+		expectedLiteral string
+	}{
+		{token.LET, "let"},
+		{token.IDENT, "five"},
+		{token.ASSIGN, "="},
+		{token.INT, "5"},
+		{token.SEMICOLON, ";"},
+		{token.LET, "let"},
+		{token.IDENT, "ten"},
+		{token.ASSIGN, "="},
+		{token.INT, "10"},
+		{token.SEMICOLON, ";"},
+		{token.LET, "let"},
+		{token.IDENT, "add"},
+		{token.ASSIGN, "="},
+		{token.FUNCTION, "fn"},
+		{token.LPAREN, "("},
+		{token.IDENT, "x"},
+		{token.COMMA, ","},
+		{token.IDENT, "y"},
+		{token.RPAREN, ")"},
+		{token.LBRACE, "{"},
+		{token.IDENT, "x"},
+		{token.PLUS, "+"},
+		{token.IDENT, "y"},
+		{token.SEMICOLON, ";"},
+		{token.RBRACE, "}"},
+		{token.SEMICOLON, ";"},
+		{token.LET, "let"},
+		{token.IDENT, "result"},
+		{token.ASSIGN, "="},
+		{token.IDENT, "add"},
+		{token.LPAREN, "("},
+		{token.IDENT, "five"},
+		{token.COMMA, ","},
+		{token.IDENT, "ten"},
+		{token.RPAREN, ")"},
+		{token.SEMICOLON, ";"},
+		{token.EOF, ""},
+	}
+
+	l := New(input)
+
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong. expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - literal wrong. expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}

--- a/token/token.go
+++ b/token/token.go
@@ -1,0 +1,34 @@
+package token
+
+type TokenType string
+
+type Token struct {
+	Type    TokenType
+	Literal string
+}
+
+const (
+	ILLEGAL = "ILLEGAL"
+	EOF     = "EOF"
+
+	// 식별자 + 리터럴
+	IDENT = "IDENT" // add, foobar, x, y
+	INT   = "INT"   // 12342
+
+	// 연산자
+	ASSIGN = "="
+	PLUS   = "+"
+
+	// 구분자
+	COMMA     = ","
+	SEMICOLON = ";"
+
+	LPAREN = "("
+	RPAREN = ")"
+	LBRACE = "{"
+	RBRACE = "}"
+
+	// 예약어
+	FUNCTION = "FUNCTION"
+	LET      = "LET"
+)


### PR DESCRIPTION
### Context
- 소스코드를 평가하기 전 과정을 아래와 같이 구분한다.
  - 소스코드 -> 토큰 -> 추상구문트리
- 이 중 첫번째 변환 작업인 '소스코드를 토큰 배열로 변환하기'를 위해 토큰의 자료구조를 정의하자

### Code
- 토큰 자료구조를 위한 token.go 추가
  - TokenType: 각 토큰의 다양한 타입을 필요한 만큼 지원하기 위해 string 으로 정의
  - Token struct: 토큰의 타입을 위한 Type 필드와, 토큰 자체를 구성하는 문자값을 위한 Literal 필드를 정의
  - 필요한 TokenType을 상수로 정의