### PR TITLE
add: 대화형 모드를 위한 REPL 추가

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"monkey/repl"
+	"os"
+	"os/user"
+)
+
+func main() {
+	user, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Hello %s! This is the Monkey programming language!\n", user.Username)
+	fmt.Printf("Feel free to in commands\n")
+	repl.Start(os.Stdin, os.Stdout)
+}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -1,0 +1,30 @@
+package repl
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"monkey/lexer"
+	"monkey/token"
+)
+
+const PROMPT = ">> "
+
+func Start(in io.Reader, out io.Writer) {
+	scanner := bufio.NewScanner(in)
+
+	for {
+		fmt.Fprintf(out, PROMPT)
+		scanned := scanner.Scan()
+		if !scanned {
+			return
+		}
+
+		line := scanner.Text()
+		l := lexer.New(line)
+
+		for tok := l.NextToken(); tok.Type != token.EOF; tok = l.NextToken() {
+			fmt.Fprintf(out, "%+v\n", tok)
+		}
+	}
+}


### PR DESCRIPTION
### Context
- 개발중인 인터프리터의 동작을 대화형으로 확인할 수 있는 REPL(Read Eval Print Loop)을 구현하자

### Changes
- repl/repl.go 추가
  - 지금은 Lexer만 구현된 상태이므로, 사용자 입력을 토큰 배열로 출력하고 평가(eval)는 하지 않는다.
  - 이후 인터프리터를 완성시키며 확장할 예정

### Test
1. `go run main.go` 실행
2. 콘솔에서 임의의 문자 입력 후 엔터
3. 입력한 문자를 lexing한 결과인 토큰 배열이 출력되는 것 확인
![image](https://github.com/user-attachments/assets/b1f64416-a000-4466-8f92-146079f661c5)
