### PR TITLE
Parser/let statement parser

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1,0 +1,51 @@
+package ast
+
+import "monkey/token"
+
+// AST를 구성하는 모든 노드는 Node 인터페이스를 구현해야한다.
+type Node interface {
+	TokenLiteral() string
+}
+
+// 명령문 노드
+type Statement interface {
+	Node
+	statementNode()
+}
+
+// 표현식 노드
+type Expression interface {
+	Node
+	expressionNode()
+}
+
+// parser가 생성하는 모든 AST의 루트 노드
+type Program struct {
+	Statements []Statement
+}
+
+// Program은 노드이므로 Node를 구현해야한다.
+func (p *Program) TokenLiteral() string {
+	if len(p.Statements) > 0 {
+		return p.Statements[0].TokenLiteral()
+	} else {
+		return ""
+	}
+}
+
+type LetStatement struct {
+	Token token.Token // token.LET
+	Name  *Identifier // 변수 바인딩 식별자. (`let x = 1 + 2;` 에서 `x`)
+	Value Expression  // 값을 생성하는 표현식. (`let x = 1 + 2;` 에서 `1 + 2`)
+}
+
+func (ls *LetStatement) statementNode()       {}
+func (ls *LetStatement) TokenLiteral() string { return ls.Token.Literal }
+
+type Identifier struct {
+	Token token.Token // token.IDENT
+	Value string
+}
+
+func (i *Identifier) expressionNode()      {}
+func (i *Identifier) TokenLiteral() string { return i.Token.Literal }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -31,7 +31,7 @@ func (p *Parser) ParseProgram() *ast.Program {
 	program := &ast.Program{}
 	program.Statements = []ast.Statement{}
 
-	for p.curToken.Type != token.EOF {
+	for !p.curTokenIs(token.EOF) {
 		stmt := p.parseStatement()
 		if stmt != nil {
 			program.Statements = append(program.Statements, stmt)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -28,5 +28,63 @@ func (p *Parser) nextToken() {
 }
 
 func (p *Parser) ParseProgram() *ast.Program {
-	return nil
+	program := &ast.Program{}
+	program.Statements = []ast.Statement{}
+
+	for p.curToken.Type != token.EOF {
+		stmt := p.parseStatement()
+		if stmt != nil {
+			program.Statements = append(program.Statements, stmt)
+		}
+		p.nextToken()
+	}
+
+	return program
+}
+
+func (p *Parser) parseStatement() ast.Statement {
+	switch p.curToken.Type {
+	case token.LET:
+		return p.parseLetStatement()
+	default:
+		return nil
+	}
+}
+
+func (p *Parser) parseLetStatement() *ast.LetStatement {
+	stmt := &ast.LetStatement{Token: p.curToken}
+
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+
+	stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+
+	if !p.expectPeek(token.ASSIGN) {
+		return nil
+	}
+
+	// TODO: 세미콜론을 만날 때 까지 표현식을 건너뛴다.
+	for !p.curTokenIs(token.SEMICOLON) {
+		p.nextToken()
+	}
+
+	return stmt
+}
+
+func (p *Parser) curTokenIs(t token.TokenType) bool {
+	return p.curToken.Type == t
+}
+
+func (p *Parser) peekTokenIs(t token.TokenType) bool {
+	return p.peekToken.Type == t
+}
+
+func (p *Parser) expectPeek(t token.TokenType) bool {
+	if p.peekTokenIs(t) {
+		p.nextToken()
+		return true
+	} else {
+		return false
+	}
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,0 +1,32 @@
+package parser
+
+import (
+	"monkey/ast"
+	"monkey/lexer"
+	"monkey/token"
+)
+
+type Parser struct {
+	l         *lexer.Lexer // 현재의 Lexer 인스턴스를 가리키는 포인터
+	curToken  token.Token  // 현재 토큰
+	peekToken token.Token  // 현재 토큰의 다음 토큰
+}
+
+func New(l *lexer.Lexer) *Parser {
+	p := &Parser{l: l}
+
+	// 토큰을 2개 읽어서 curToken과 peekToken을 세팅
+	p.nextToken()
+	p.nextToken()
+
+	return p
+}
+
+func (p *Parser) nextToken() {
+	p.curToken = p.peekToken
+	p.peekToken = p.l.NextToken()
+}
+
+func (p *Parser) ParseProgram() *ast.Program {
+	return nil
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"monkey/ast"
 	"monkey/lexer"
 	"monkey/token"
@@ -10,10 +11,14 @@ type Parser struct {
 	l         *lexer.Lexer // 현재의 Lexer 인스턴스를 가리키는 포인터
 	curToken  token.Token  // 현재 토큰
 	peekToken token.Token  // 현재 토큰의 다음 토큰
+	errors    []string
 }
 
 func New(l *lexer.Lexer) *Parser {
-	p := &Parser{l: l}
+	p := &Parser{
+		l:      l,
+		errors: []string{},
+	}
 
 	// 토큰을 2개 읽어서 curToken과 peekToken을 세팅
 	p.nextToken()
@@ -40,6 +45,15 @@ func (p *Parser) ParseProgram() *ast.Program {
 	}
 
 	return program
+}
+
+func (p *Parser) Errors() []string {
+	return p.errors
+}
+
+func (p *Parser) peekError(t token.TokenType) {
+	msg := fmt.Sprintf("expected next token to be %s, got %s instead", t, p.peekToken.Type)
+	p.errors = append(p.errors, msg)
 }
 
 func (p *Parser) parseStatement() ast.Statement {
@@ -85,6 +99,7 @@ func (p *Parser) expectPeek(t token.TokenType) bool {
 		p.nextToken()
 		return true
 	} else {
+		p.peekError(t)
 		return false
 	}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,0 +1,66 @@
+package parser
+
+import (
+	"monkey/ast"
+	"monkey/lexer"
+	"testing"
+)
+
+func TestLetStatement(t *testing.T) {
+	input := `
+let x = 5;
+let y = 10;
+let foobar = 838383;
+`
+
+	l := lexer.New(input)
+	p := New(l)
+
+	program := p.ParseProgram()
+	if program == nil {
+		t.Fatalf("ParseProgram() returned nil")
+	}
+	if len(program.Statements) != 3 {
+		t.Fatalf("program.Statements does not contain 3 statements. got=%d", len(program.Statements))
+	}
+
+	tests := []struct {
+		expectedIdentifier string
+	}{
+		{"x"},
+		{"y"},
+		{"foobar"},
+	}
+
+	for i, tt := range tests {
+		stmt := program.Statements[i]
+		if !testLetStatement(t, stmt, tt.expectedIdentifier) {
+			return
+		}
+	}
+}
+
+func testLetStatement(t *testing.T, s ast.Statement, name string) bool {
+	if s.TokenLiteral() != "let" {
+		t.Errorf("s.TokenLiteral not 'let'. got=%q", s.TokenLiteral())
+		return false
+	}
+
+	letStmt, ok := s.(*ast.LetStatement)
+	if !ok {
+		t.Errorf("s not *ast.LetStatement. got=%T", s)
+		return false
+	}
+
+	if letStmt.Name.Value != name {
+		t.Errorf("letStmt.Name.Value not '%s'. got=%s", name, letStmt.Name.Value)
+		return false
+	}
+
+	if letStmt.Name.TokenLiteral() != name {
+		t.Errorf("letStmt.Name.TokenLiteral() not '%s'. got=%s", name, letStmt.Name.TokenLiteral())
+		return false
+	}
+
+	return true
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -17,6 +17,7 @@ let foobar = 838383;
 	p := New(l)
 
 	program := p.ParseProgram()
+	checkParserError(t, p)
 	if program == nil {
 		t.Fatalf("ParseProgram() returned nil")
 	}
@@ -38,6 +39,19 @@ let foobar = 838383;
 			return
 		}
 	}
+}
+
+func checkParserError(t *testing.T, p *Parser) {
+	errors := p.Errors()
+	if len(errors) == 0 {
+		return
+	}
+
+	t.Errorf("parser has %d errors", len(errors))
+	for _, msg := range errors {
+		t.Errorf("parser error: %q", msg)
+	}
+	t.FailNow()
 }
 
 func testLetStatement(t *testing.T, s ast.Statement, name string) bool {


### PR DESCRIPTION
### Context
- 식별자 이름에 표현식을 할당하는 구문인 `let`구문에 대한 parser를 구현하자
- monkey 언어에서 let 구문은 다음과 같이 표현할 수 있다.
  - `let <identifier> = <expression>;`

### Code
- ast.go
  - 소스코드를 내부적으로 표현하기 위해 사용하는 자료구조인 추상구문트리(AST; Abstract Statement Tree)를 구현하는 모듈
  - tokenize된 소스코드가 parser를 통해 구문 분석(파싱)되어 결과물을 AST로 생성한다.
  - AST의 모든 노드는 `Node` interface를 구현해야한다.
    - 명령문 노드는 `Statement` interface로 구현해야한다.
    - 표현식 노드는 `Expression` interface를 구현해야한다.
    - `Statement`, `Expression`는 `Node`를 embedding한다.
  - parser의 구문분석 결과로 생성되는 AST의 루트노드를 `Program`이라는 구조체로 정의하고, `Program`은 노드이므로 `Node` interface를 구현한다.
  - `let` statement 노드는 `LetStatement`라는 구조체로 정의하고 `Statement` interface를 구현한다.
  - let 구문의 `<identifier>`는 `Identifier`라는 구조체로 정의한다.
    - `Identifier`가 `Expression` interface를 구현하는데,
       1. let 구문에서의 `<Identifier>`는 값을 셍성하지 않기 때문에 표현식으로 처리하지 않아도 되기는 한다.
       2. 그러나 저자는 monkey 언어의 다른 부분에서는 `Identifier`가 값을 생성할 수 있기 때문에(`let a = b;`에서 `b`는 식별자이면서 표현식이다.), 모든 식별자가 표현식으로 처리될 수 있도록 구현했다고 설명한다.
       
- parser.go
  - Parser 구조체는 Lexer 인스턴스의 포인터와 현재 토큰, 다음 토큰을 필드로 갖고 다음의 동작을 수행한다.
    - 초기화(`New`): Lexer 인스턴스를 받아 필드에 저장하고, `Parser.nextToken`을 2번 호출하여 현재 토큰, 다음 토큰 필드를 채운다.
    - parsing(`ParseProgram`): parser가 생성할 AST의 루트 노드인 `Program` 구조체의 인스턴스(`program`)를 생성하고, 토큰을 모두 순회하며 구문분석 후 `program.Statements` 필드에 append한다.
      - 각 토큰에 대한 구문분석은 토큰 타입에 따라 처리된다.(본 PR에서는 `let` 구문에 대한 분석만 구현되어있으므로, `LET` 타입 토큰에 대해서만 처리된다.)
      - `LET`타입 토큰에 대한 구문분석은 `let <identifier> = <expression>;` 으로 표현되는 let 구문의 `<identifier>`, `=(ASSIGN)`, `<expression>`, `;(SEMICOLON)` 토큰을 읽어들이는것으로 진행된다.
      - 위와 같은 순서로 기대한 각 토큰이 나타나지 않는 경우(`expectPeek`이 false), 에러로 간주하고 `Parser.errors` 필드를 채운다
      - 표현식에 대한 구문분석은 아직 구현되어있지 않기 때문에 건너뛴다.(L82-84)
      - 구문내의 모든 토큰이 기대와 일치할 경우 `LetStatement` 타입의 인스턴스를 반환하며, 하나의 let 구문에 대한 구문분석을 마친다.

- parser_test.go
  - 가독성을 위해 토큰배열이 아닌 monkey 소스코드 자체를 input으로 사용해 테스트한다.
  - `checkParserError`함수를 통해 `Parser.errors`배열에 값이 있는지 여부를 확인하고, 있다면 구문분석 중 오류가 난 것이므로 오류를 출력하고 테스트를 중단한다.
  - `testLetStatement`함수는 인자로 들어온 구문(s)이 let 구문이 맞는지 체크하고(토큰 타입 체크, 인스턴스 타입 체크), 식별자의 이름이 있어야 하는 각 필드가 정확하게 채워졌는지 체크한다.