### PR TITLE
Parser/return statement parser

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -33,6 +33,7 @@ func (p *Program) TokenLiteral() string {
 	}
 }
 
+// let <identifier> = <expression>;
 type LetStatement struct {
 	Token token.Token // token.LET
 	Name  *Identifier // 변수 바인딩 식별자. (`let x = 1 + 2;` 에서 `x`)
@@ -41,6 +42,15 @@ type LetStatement struct {
 
 func (ls *LetStatement) statementNode()       {}
 func (ls *LetStatement) TokenLiteral() string { return ls.Token.Literal }
+
+// return <expression>;
+type ReturnStatement struct {
+	Token       token.Token // token.RETURN
+	ReturnValue Expression
+}
+
+func (rs *ReturnStatement) statementNode()       {}
+func (rs *ReturnStatement) TokenLiteral() string { return rs.Token.Literal }
 
 type Identifier struct {
 	Token token.Token // token.IDENT

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -60,6 +60,8 @@ func (p *Parser) parseStatement() ast.Statement {
 	switch p.curToken.Type {
 	case token.LET:
 		return p.parseLetStatement()
+	case token.RETURN:
+		return p.parseReturnStatement()
 	default:
 		return nil
 	}
@@ -84,6 +86,19 @@ func (p *Parser) parseLetStatement() *ast.LetStatement {
 	}
 
 	return stmt
+}
+
+func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
+	returnStmt := &ast.ReturnStatement{Token: p.curToken}
+
+	p.nextToken()
+
+	// TODO: 세미콜론을 만날 때 까지 표현식을 건너뛴다.
+	for !p.curTokenIs(token.SEMICOLON) {
+		p.nextToken()
+	}
+
+	return returnStmt
 }
 
 func (p *Parser) curTokenIs(t token.TokenType) bool {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -66,6 +66,34 @@ func testLetStatement(t *testing.T, s ast.Statement, name string) bool {
 	return true
 }
 
+func TestReturnStatement(t *testing.T) {
+	input := `
+return 5;
+return 10;
+return 993322;
+`
+	lexer := lexer.New(input)
+	p := New(lexer)
+
+	program := p.ParseProgram()
+	checkParserError(t, p)
+
+	if len(program.Statements) != 3 {
+		t.Fatalf("program.Statements does not contain 3 statements. got=%d", len(program.Statements))
+	}
+
+	for _, stmt := range program.Statements {
+		returnStmt, ok := stmt.(*ast.ReturnStatement)
+		if !ok {
+			t.Errorf("stmt not *ast.ReturnStatement. got=%T", stmt)
+			continue
+		}
+		if returnStmt.TokenLiteral() != "return" {
+			t.Errorf("returnStmt.TokenLiteral() not 'return'. got=%s", returnStmt.TokenLiteral())
+		}
+	}
+}
+
 func checkParserError(t *testing.T, p *Parser) {
 	errors := p.Errors()
 	if len(errors) == 0 {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -41,19 +41,6 @@ let foobar = 838383;
 	}
 }
 
-func checkParserError(t *testing.T, p *Parser) {
-	errors := p.Errors()
-	if len(errors) == 0 {
-		return
-	}
-
-	t.Errorf("parser has %d errors", len(errors))
-	for _, msg := range errors {
-		t.Errorf("parser error: %q", msg)
-	}
-	t.FailNow()
-}
-
 func testLetStatement(t *testing.T, s ast.Statement, name string) bool {
 	if s.TokenLiteral() != "let" {
 		t.Errorf("s.TokenLiteral not 'let'. got=%q", s.TokenLiteral())
@@ -77,4 +64,17 @@ func testLetStatement(t *testing.T, s ast.Statement, name string) bool {
 	}
 
 	return true
+}
+
+func checkParserError(t *testing.T, p *Parser) {
+	errors := p.Errors()
+	if len(errors) == 0 {
+		return
+	}
+
+	t.Errorf("parser has %d errors", len(errors))
+	for _, msg := range errors {
+		t.Errorf("parser error: %q", msg)
+	}
+	t.FailNow()
 }


### PR DESCRIPTION
### Context
- return 구문에 대한 구문분석 처리 로직을 추가하자
- https://github.com/jaehyeonkim2358/monkey/pull/10 의 작업을 return 구문에 대해서도 처리하는 것
- `return <expression>;`

### Code
- ast.go
  - ReturnStatement 구조체 추가
    - Token과 ReturnValue를 필드로 갖고 Statement interface를 구현함
- parser.go
  - 토큰 타입이 token.RETURN 인 경우에 대한 처리 추가
  - return 구문은 'return' 키워드와 세미콜론 사이에 표현식이 위치함
  - 현재 표현식에 대한 구문분석 처리가 구현되어있지 않아 세미콜론 전까지 표현식을 건너뛰도록 구현